### PR TITLE
Remove coffee-script runtime dependency, publish as plain JS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.iml
 .idea
+dist/

--- a/index.js
+++ b/index.js
@@ -2,11 +2,7 @@
 /* jshint -W097 */
 'use strict';
 
-
-var coffee = require('coffee-script');
-coffee.register();
-
 module.exports = {};
-module.exports.FtpConnectionError = require('./lib/ftpConnectionError');
-module.exports.FtpReconnectError = require('./lib/ftpReconnectError');
-module.exports.STATUSES = require('./lib/connectionStatuses');
+module.exports.FtpConnectionError = require('./dist/ftpConnectionError');
+module.exports.FtpReconnectError = require('./dist/ftpReconnectError');
+module.exports.STATUSES = require('./dist/connectionStatuses');

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "Joe Ibershoff <joe@realtymaps.com>",
     "Moti Zilberman <motiz88@gmail.com>"
   ],
-  "directories": {
-    "dist": "./dist"
-  },
+  "files": [
+    "dist",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/realtymaps/promise-ftp-common"

--- a/package.json
+++ b/package.json
@@ -5,20 +5,25 @@
   "main": "index.js",
   "author": "RealtyMaps",
   "contributors": [
-    "Joe Ibershoff <joe@realtymaps.com>"
+    "Joe Ibershoff <joe@realtymaps.com>",
+    "Moti Zilberman <motiz88@gmail.com>"
   ],
   "directories": {
-    "lib": "./lib"
+    "dist": "./dist"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/realtymaps/promise-ftp-common"
   },
-  "dependencies": {
+  "devDependencies": {
     "coffee-script": "1.x"
   },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/realtymaps/promise-ftp-common/issues"
+  },
+  "scripts": {
+    "build": "coffee --compile --output dist/ lib/",
+    "dev": "coffee --watch --output dist lib/"
   }
 }


### PR DESCRIPTION
This is required to allow a similar step to be taken with `promise-ftp`: https://github.com/realtymaps/promise-ftp/pull/1
